### PR TITLE
Fix multiplayer movement

### DIFF
--- a/src/main/java/org/lanternpowered/server/network/entity/vanilla/EntityProtocol.java
+++ b/src/main/java/org/lanternpowered/server/network/entity/vanilla/EntityProtocol.java
@@ -179,7 +179,7 @@ public abstract class EntityProtocol<E extends LanternEntity> extends AbstractEn
             // Don't send movement messages if the entity
             // is a passengers, otherwise glitches will
             // rule the world.
-            if (passenger) {
+            if (!passenger) {
                 if (Math.abs(dxu) <= Short.MAX_VALUE && Math.abs(dyu) <= Short.MAX_VALUE && Math.abs(dzu) <= Short.MAX_VALUE) {
                     if (dirtyRot) {
                         context.sendToAllExceptSelf(new MessagePlayOutEntityLookAndRelativeMove(entityId,


### PR DESCRIPTION
You would not see other player's move due to this boolean check being opposite of what it is supposed to be