### PR TITLE
Add dummy timings

### DIFF
--- a/src/main/java/org/lanternpowered/server/game/LanternGameRegistry.java
+++ b/src/main/java/org/lanternpowered/server/game/LanternGameRegistry.java
@@ -91,6 +91,7 @@ import org.lanternpowered.server.game.registry.CatalogMappingDataHolder;
 import org.lanternpowered.server.game.registry.EarlyRegistration;
 import org.lanternpowered.server.game.registry.EnumValueRegistryModule;
 import org.lanternpowered.server.game.registry.factory.ResourcePackFactoryModule;
+import org.lanternpowered.server.game.registry.factory.TimingsFactoryRegistryModule;
 import org.lanternpowered.server.game.registry.type.advancement.AdvancementTreeRegistryModule;
 import org.lanternpowered.server.game.registry.type.attribute.AttributeOperationRegistryModule;
 import org.lanternpowered.server.game.registry.type.attribute.AttributeRegistryModule;
@@ -613,6 +614,7 @@ public class LanternGameRegistry implements GameRegistry {
     private void registerFactories() {
         final List<FactoryRegistry<?, ?>> factoryRegistries = new ArrayList<>();
         factoryRegistries.add(new ResourcePackFactoryModule());
+        factoryRegistries.add(new TimingsFactoryRegistryModule());
 
         try {
             for (FactoryRegistry<?, ?> registry : factoryRegistries) {

--- a/src/main/java/org/lanternpowered/server/game/registry/factory/DummyLanternTiming.java
+++ b/src/main/java/org/lanternpowered/server/game/registry/factory/DummyLanternTiming.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of LanternServer, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) LanternPowered <https://www.lanternpowered.org>
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the Software), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.lanternpowered.server.game.registry.factory;
+
+import co.aikar.timings.Timing;
+
+public class DummyLanternTiming implements Timing {
+
+    @Override
+    public Timing startTiming() {
+        return this;
+    }
+
+    @Override
+    public void stopTiming() {
+        // Ignore
+    }
+
+    @Override
+    public void startTimingIfSync() {
+        // Ignore
+    }
+
+    @Override
+    public void stopTimingIfSync() {
+        // Ignore
+    }
+
+    @Override
+    public void abort() {
+        // Ignore
+    }
+
+    @Override
+    public void close() {
+        // Ignore
+    }
+}

--- a/src/main/java/org/lanternpowered/server/game/registry/factory/DummyLanternTimingsFactory.java
+++ b/src/main/java/org/lanternpowered/server/game/registry/factory/DummyLanternTimingsFactory.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of LanternServer, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) LanternPowered <https://www.lanternpowered.org>
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the Software), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.lanternpowered.server.game.registry.factory;
+
+import co.aikar.timings.Timing;
+import co.aikar.timings.TimingsFactory;
+import org.spongepowered.api.command.CommandSource;
+
+import javax.annotation.Nullable;
+
+public class DummyLanternTimingsFactory implements TimingsFactory {
+
+    private static final Timing DUMMY_TIMING = new DummyLanternTiming();
+
+    public void init() {
+        // Ignore
+    }
+
+    @Override
+    public Timing of(Object plugin, String name, @Nullable Timing groupHandler) {
+        return DUMMY_TIMING;
+    }
+
+    @Override
+    public boolean isTimingsEnabled() {
+        return false;
+    }
+
+    @Override
+    public void setTimingsEnabled(boolean enabled) {
+        // Ignore
+    }
+
+    @Override
+    public boolean isVerboseTimingsEnabled() {
+        return false;
+    }
+
+    @Override
+    public void setVerboseTimingsEnabled(boolean enabled) {
+        // Ignore
+    }
+
+    @Override
+    public int getHistoryInterval() {
+        return 0;
+    }
+
+    @Override
+    public void setHistoryInterval(int interval) {
+        // Ignore
+    }
+
+    @Override
+    public int getHistoryLength() {
+        return 0;
+    }
+
+    @Override
+    public void setHistoryLength(int length) {
+        // Ignore
+    }
+
+    @Override
+    public void reset() {
+        // Ignore
+    }
+
+    @Override
+    public void generateReport(@Nullable CommandSource source) {
+        // Ignore
+    }
+}

--- a/src/main/java/org/lanternpowered/server/game/registry/factory/TimingsFactoryRegistryModule.java
+++ b/src/main/java/org/lanternpowered/server/game/registry/factory/TimingsFactoryRegistryModule.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of LanternServer, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) LanternPowered <https://www.lanternpowered.org>
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the Software), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.lanternpowered.server.game.registry.factory;
+
+import co.aikar.timings.Timings;
+import co.aikar.timings.TimingsFactory;
+import org.spongepowered.api.registry.FactoryRegistry;
+
+public class TimingsFactoryRegistryModule implements FactoryRegistry<TimingsFactory, Timings> {
+
+    @Override
+    public Class<Timings> getFactoryOwner() {
+        return Timings.class;
+    }
+
+    @Override
+    public TimingsFactory provideFactory() {
+        return Holder.INSTANCE;
+    }
+
+    @Override
+    public void initialize() {
+        // Ignore
+    }
+
+    private static final class Holder {
+        static final DummyLanternTimingsFactory INSTANCE = new DummyLanternTimingsFactory();
+    }
+
+}


### PR DESCRIPTION
Also has extra safety in case plugins don't check if timings is enabled, etc. These changes allowed Nucleus to work.

This will probably be our best solution for a while, as we don't really need timings at the moment, it's quite a lot of work to fully implement, and it may never fit that well with our setup. 